### PR TITLE
only set .withCredentials on an opened asynchronous XMLHttpRequest

### DIFF
--- a/src/stdlib/IntelliFactory.WebSharper/Remoting.fs
+++ b/src/stdlib/IntelliFactory.WebSharper/Remoting.fs
@@ -53,8 +53,10 @@ type IAjaxProvider =
 
 [<A.Direct @"
     var xhr = new XMLHttpRequest();
-    xhr.withCredentials = true;
     xhr.open('POST', $url, $async);
+    if ($async == true) {
+        xhr.withCredentials = true;
+    }
     for (var h in $headers) {
         xhr.setRequestHeader(h, $headers[h]);
     }


### PR DESCRIPTION
Fixes #330 