### PR TITLE
Make Remoting.context thread-local, pass it through Server.HandleRequest

### DIFF
--- a/src/compiler/WebSharper.Core/Remoting.fs
+++ b/src/compiler/WebSharper.Core/Remoting.fs
@@ -166,8 +166,9 @@ let handle getConverter req =
         let m = M.MethodHandle.Unpack m
         let args = J.Parse req.Body
         let conv = getConverter m
+        let convd = conv args
         async {
-            let! x = conv args
+            let! x = convd
             let r = J.Stringify x
             return {
                 ContentType = "application/json"


### PR DESCRIPTION
This change is intended to help fixing [websharper.owin#4](https://github.com/intellifactory/websharper.owin/issues/4) (see [this discussion](https://github.com/intellifactory/websharper.owin/pull/5)), but it also makes the code cleaner in and of itself by pulling the thread-localness constraint from websharper.owin to websharper itself.