### PR TITLE
Add support for pointing resources to a CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ IntelliFactory.WebSharper.JQuery/*.js
 /packages/
 /tools/packages/
 /tests/Web/downloads/
+/msbuild/AssemblyInfo.extra.fs

--- a/msbuild/AssemblyInfo.extra.fs.in
+++ b/msbuild/AssemblyInfo.extra.fs.in
@@ -1,0 +1,27 @@
+// $begin{copyright}
+//
+// This file is part of WebSharper
+//
+// Copyright (c) 2008-2015 IntelliFactory
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// $end{copyright}
+
+namespace WebSharper
+
+open System
+open System.Reflection
+
+[<assembly: AssemblyFileVersion("{version}")>]
+do ()

--- a/msbuild/FSharp.targets
+++ b/msbuild/FSharp.targets
@@ -77,6 +77,7 @@
       <C Include="@(Compile)" />
       <Compile Remove="@(C)" />
       <Compile Include="$(MSBuildThisFileDirectory)/AssemblyInfo.fs" />
+      <Compile Include="$(MSBuildThisFileDirectory)/AssemblyInfo.extra.fs" Condition="Exists('$(MSBuildThisFileDirectory)/AssemblyInfo.extra.fs')" />
       <Compile Include="@(C)" />
     </ItemGroup>
   </Target>

--- a/src/compiler/WebSharper.Core/Metadata.fs
+++ b/src/compiler/WebSharper.Core/Metadata.fs
@@ -209,7 +209,11 @@ type Type = Re.TypeDefinition
 type AssemblyResource(name: Re.AssemblyName) =
     interface R.IResource with
         member this.Render ctx writer =
-            let r = ctx.GetAssemblyRendering name
+            let filename = name.Name + if ctx.DebuggingEnabled then ".js" else ".min.js"
+            let r =
+                match R.Rendering.TryGetCdn(ctx, name, filename) with
+                | Some r -> r
+                | None -> ctx.GetAssemblyRendering name
             r.Emit(writer R.Scripts, R.Js)
 
 let activate resource =

--- a/src/compiler/WebSharper.Core/Resources.fs
+++ b/src/compiler/WebSharper.Core/Resources.fs
@@ -179,7 +179,7 @@ type BaseResource(kind: Kind) =
                     | Some url -> RenderLink url
                     | None ->
                         match tryFindWebResource self spec with
-                        | Some e -> Rendering.GetWebResourceRendering(ctx, self, spec)
+                        | Some e -> Rendering.GetWebResourceRendering(ctx, self, e)
                         | None -> RenderLink spec
                 r.Emit(writer, mt, dHttp)
             | Complex (b, xs) ->

--- a/src/compiler/WebSharper.Core/Resources.fsi
+++ b/src/compiler/WebSharper.Core/Resources.fsi
@@ -43,9 +43,12 @@ type Rendering =
 
     member Emit : HtmlTextWriter * MediaType * ?defaultToHttp: bool -> unit
     member Emit : (RenderLocation -> HtmlTextWriter) * MediaType * ?defaultToHttp: bool -> unit
+    static member TryGetCdn : ctx: Context * assemblyName: R.AssemblyName * filename: string -> option<Rendering>
+    static member TryGetCdn : ctx: Context * assembly: System.Reflection.Assembly * filename: string -> option<Rendering>
+    static member GetWebResourceRendering : ctx: Context * resource: System.Type * filename: string -> Rendering
 
 /// Defines the context in which resources can be rendered.
-type Context =
+and Context =
     {
         /// A flag indicating if debugging is enabled or not.
         DebuggingEnabled : bool

--- a/src/stdlib/WebSharper.Main/JavaScript.fs
+++ b/src/stdlib/WebSharper.Main/JavaScript.fs
@@ -24,6 +24,7 @@
 module WebSharper.JavaScript.JS
 
 module A = WebSharper.Core.Attributes
+module R = WebSharper.Core.Reflection
 module Re = WebSharper.Core.Resources
 
 type AnimationFrameResource() =
@@ -32,7 +33,7 @@ type AnimationFrameResource() =
             let html = html Re.Scripts
             html.WriteLine "<!--[if lte IE 9.0]>"
             let name = if ctx.DebuggingEnabled then "AnimFrame.js" else "AnimFrame.min.js"
-            let ren = ctx.GetWebResourceRendering typeof<AnimationFrameResource> name
+            let ren = Re.Rendering.GetWebResourceRendering(ctx, typeof<AnimationFrameResource>, name)
             ren.Emit(html, Re.Js)
             html.WriteLine "<![endif]-->"
 

--- a/src/stdlib/WebSharper.Main/Json.fs
+++ b/src/stdlib/WebSharper.Main/Json.fs
@@ -31,7 +31,7 @@ type Resource() =
             let html = html Re.Scripts
             html.WriteLine "<!--[if lte IE 7.0]>"
             let name = if ctx.DebuggingEnabled then "Json.js" else "Json.min.js"
-            let ren = ctx.GetWebResourceRendering typeof<Resource> name
+            let ren = Re.Rendering.GetWebResourceRendering(ctx, typeof<Resource>, name)
             ren.Emit(html, Re.Js)
             html.WriteLine "<![endif]-->"
 


### PR DESCRIPTION
The algorithm to choose what URL to emit for assembly resources and embedded resources is as follows:

* If there is a configuration variable called `WebSharper.CdnFormat.<assemblyname>`, then use it as URL format.
* Else, if the assembly is part of the standard library and the configuration variable `WebSharper.StdlibUseCdn` is true, then use the stdlib CDN URL format, which is `//cdn.websharper.com/{assembly}/{version}/{filename}` by default but can be overridden by the configuration variable `WebSharper.StdlibCdnFormat`.
* Else, revert to the usual rendering.