### PR TITLE
Static members can be proxied from across multiple dll-s

### DIFF
--- a/tests/WebSharper.Collections.Tests/SplitProxy.fs
+++ b/tests/WebSharper.Collections.Tests/SplitProxy.fs
@@ -1,0 +1,36 @@
+﻿// $begin{copyright}
+//
+// This file is part of WebSharper
+//
+// Copyright (c) 2008-2016 IntelliFactory
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// $end{copyright}
+
+module WebSharper.Collections.Tests.SplitProxy
+
+module ClassInfoMergeTestType =
+    let Member1 () = "member1"
+    let Member2 () = "member2"
+
+open WebSharper
+open WebSharper.JavaScript.Interop
+
+[<Proxy "WebSharper.Collections.Tests.SplitProxy.ClassInfoMergeTestType">]
+module private TestTypeProxy =
+    [<Name "WebSharper.Collections.Tests.SplitProxy.ClassInfoMergeTestType.Member1">]
+    let [<Inline "'member1'">] Member1 () = X<string>
+
+
+

--- a/tests/WebSharper.Collections.Tests/WebSharper.Collections.Tests.fsproj
+++ b/tests/WebSharper.Collections.Tests/WebSharper.Collections.Tests.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="HashSet.fs" />
     <Compile Include="Interop.fs" />
     <Compile Include="Main.fs" />
+    <Compile Include="SplitProxy.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\compiler\WebSharper.Core\WebSharper.Core.fsproj">

--- a/tests/WebSharper.Tests/Proxy.fs
+++ b/tests/WebSharper.Tests/Proxy.fs
@@ -21,6 +21,7 @@
 module WebSharper.Tests.Proxy
 
 open WebSharper
+open WebSharper.Collections.Tests.SplitProxy
 open WebSharper.JavaScript
 open WebSharper.Testing
 module R = WebSharper.Testing.Random
@@ -51,6 +52,11 @@ type IIsClientClass [<JavaScript>] () =
     interface IIsClient with
         member this.IsClient() = false
 
+[<Proxy "WebSharper.Collections.Tests.SplitProxy.ClassInfoMergeTestType">]
+module private TestTypeProxy =
+    [<Name "WebSharper.Collections.Tests.SplitProxy.ClassInfoMergeTestType.Member2">]
+    let [<Inline "'member2'">] Member2 () = X<string>
+
 [<JavaScript>]
 let Tests =
 
@@ -66,5 +72,10 @@ let Tests =
 
         Test "Interface with JavaScript false" {
             isTrue ((IIsClientClass() :> IIsClient).IsClient())
+        }
+
+        Test "Split proxy compilation" {
+            equalMsg (ClassInfoMergeTestType.Member1 ()) "member1" "Member1 compiled"
+            equalMsg (ClassInfoMergeTestType.Member2 ()) "member2" "Member2 compiled"
         }
     }

--- a/tests/WebSharper.Tests/WebSharper.Tests.fsproj
+++ b/tests/WebSharper.Tests/WebSharper.Tests.fsproj
@@ -103,6 +103,11 @@
       <Project>{a28d0cc6-9c9c-4438-81e2-0c21fb9549a3}</Project>
       <Private>True</Private>
     </ProjectReference>
+    <ProjectReference Include="..\WebSharper.Collections.Tests\WebSharper.Collections.Tests.fsproj">
+      <Name>WebSharper.Collections.Tests</Name>
+      <Project>{bb4817e7-12a1-4622-b8ce-29cb3c406851}</Project>
+      <Private>True</Private>
+    </ProjectReference>
     <ProjectReference Include="..\WebSharper.InterfaceGenerator.Tests\WebSharper.InterfaceGenerator.Tests.fsproj">
       <Name>WebSharper.InterfaceGenerator.Tests</Name>
       <Project>{4c826618-e150-40f7-b13a-9182f0c3eaca}</Project>


### PR DESCRIPTION
Allows splitting proxies between multiple libraries. All except one must be all static methods with no extra Macro/Name annotation on the type itself.